### PR TITLE
Fix polyfill

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,13 @@
 {
-  "presets": ["es2015"]
+  "presets": [
+    ["env", {
+      "targets": {
+        "browsers": ["last 2 versions", "iOS >=10", "ie >= 10"]
+      }
+    }]
+  ],
+  "plugins": [
+    "transform-object-assign",
+    "transform-runtime",
+  ]
 }

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -10,3 +10,4 @@ Cerner Corporation
 [@gneatgeek]: https://github.com/gneatgeek
 [@calebmeyer]: https://github.com/calebmeyer
 [@marcbachmann]: https://github.com/marcbachmann
+[@kafkahw]: https://github.com/kafkahw

--- a/package.json
+++ b/package.json
@@ -21,7 +21,9 @@
   "devDependencies": {
     "babel-cli": "^6.11.4",
     "babel-core": "^6.13.1",
-    "babel-preset-es2015": "^6.6.0",
+    "babel-plugin-transform-object-assign": "^6.22.0",
+    "babel-plugin-transform-runtime": "^6.23.0",
+    "babel-preset-env": "^1.6.0",
     "chai": "3.5.0",
     "eslint": "^2.11.1",
     "eslint-config-airbnb-base": "^3.0.1",
@@ -29,6 +31,7 @@
     "mocha": "2.4.5"
   },
   "dependencies": {
+    "babel-runtime": "^6.26.0",
     "uuid": "^3.0.0"
   },
   "engines": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jsonrpc-dispatch",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "description": "An unopinionated JSONRPC dispatcher for JavaScript",
   "main": "lib/src/index.js",
   "scripts": {


### PR DESCRIPTION
### Summary
This PR removes the need of adding polyfills when consuming jsonrpc-dispatch in browsers that don't support promise and object.assign natively.

### Additional Details
The consumers of jsonrpc-dispatch can still choose to include a global polyfill in their app because polyfills added in this PR are local and won't pollute global.

Thanks for contributing to jsonrpc-dispatch. 

[CONTRIBUTORS.md]: ../blob/master/CONTRIBUTORS.md
[License]: ../blob/master/LICENSE
